### PR TITLE
Change Fennel Git URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,7 @@
 - functions: `js2py.translate_js`, `js2py.translate_file`
 
 ### Fennel
-
-- https://github.com/bakpakin/Fennel - 2K stars
+- https://git.sr.ht/~technomancy/fennel - [2K stars](https://github.com/bakpakin/Fennel)
 - https://fennel-lang.org/
 - docs:
    - https://technomancy.us/192 - self-hosting, bootstrapping


### PR DESCRIPTION
Fennel moved away from GitHub for their development, so I've changed the old GitHub link to their new sourcehut Git repo

Also decided to add a link to the old GitHub repo for the stars count, since there's no rating system on the new repo and it's still relevant info when listing the project